### PR TITLE
Allow the api base endpoint to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ Pass client to function calls described in documentation:
 iex(2)> Mixduty.Users.list(client)
 ```
 
+## Configuration
+
+The following configuration options are available:
+```elixir
+config :mixduty,
+  base_url: "https://api.pagerduty.com/"
+```
+
 ## License
 [MIT](https://opensource.org/licenses/MIT)
 

--- a/lib/mixduty.ex
+++ b/lib/mixduty.ex
@@ -4,26 +4,24 @@ defmodule Mixduty do
   alias Mixduty.Client
   alias Poison, as: JSON
 
-  @endpoint "https://api.pagerduty.com/"
-
   def get(path, client, params \\ [], options \\ []) do
-    url = @endpoint <> path <> "?" <> URI.encode_query(params)
+    url = endpoint() <> path <> "?" <> URI.encode_query(params)
 
     raw_request(:get, url, client, options)
   end
 
   def post(path, client, body \\ "") do
-    url = @endpoint <> path
+    url = endpoint() <> path
     raw_request(:post, url, client, JSON.encode!(body))
   end
 
   def delete(path, client, body \\ "") do
-    url = @endpoint <> path
+    url = endpoint() <> path
     raw_request(:delete, url, client, JSON.encode!(body))
   end
 
   def put(path, client, body \\ "") do
-    url = @endpoint <> path
+    url = endpoint() <> path
     raw_request(:put, url, client, JSON.encode!(body))
   end
 
@@ -57,5 +55,9 @@ defmodule Mixduty do
 
   def parse_json({:error, err}, _) do
     {:error, "Could not parse response", err}
+  end
+
+  defp endpoint do
+    Application.get_env(:mixduty, :base_url, "https://api.pagerduty.com/")
   end
 end


### PR DESCRIPTION
I want to be able to run a mock Pagerduty API server in my tests, and in order to consume it I need to be able to configure the base url this library talks to. In order to do that, this PR checks for a `:mixduty, base_url:` config in the Application first before using the default base URL.