### PR TITLE
Change parameters order

### DIFF
--- a/lib/mixduty/incidents.ex
+++ b/lib/mixduty/incidents.ex
@@ -63,12 +63,12 @@ defmodule Mixduty.Incidents do
   end
 
   @doc """
-  Get list of notification subscriberst
+  Get list of notification subscribers
   #### Example
-      Mixduty.Incident.list_notification_subscribers("P00PBUG", client)
+      Mixduty.Incident.list_notification_subscribers(client, "P00PBUG")
 
   """
-  def list_notification_subscribers(incident_id, client) do
+  def list_notification_subscribers(client, incident_id) do
     @path
     |> Path.join(incident_id)
     |> Path.join("status_updates")

--- a/lib/mixduty/incidents.ex
+++ b/lib/mixduty/incidents.ex
@@ -64,9 +64,10 @@ defmodule Mixduty.Incidents do
 
   @doc """
   Get list of notification subscribers
-  #### Example
-      Mixduty.Incident.list_notification_subscribers(client, "P00PBUG")
-
+  #### Examples
+      - Mixduty.Incident.list_notification_subscribers(client, "P00PBUG")
+      - Mixduty.Client.new(token)
+        |> Mixduty.Incident.list_notification_subscribers("P00PBUG")
   """
   def list_notification_subscribers(client, incident_id) do
     @path


### PR DESCRIPTION
Decided to keep `client` as first parameter for more convenience in pipes

```
Mixduty.Client.new(token, type: :bearer)
    |> Mixduty.Incidents.list_notification_subscribers(incident_id)
```